### PR TITLE
Bugfix: generate inserts with null values instead of empty values

### DIFF
--- a/includes/class-xcloner-database.php
+++ b/includes/class-xcloner-database.php
@@ -513,13 +513,16 @@ class Xcloner_Database extends wpdb {
 					$this->countRecords++;
 
 					foreach ($arr as $key => $value) {
-						$value = $this->_real_escape($value);
-						
-						if (method_exists($this, 'remove_placeholder_escape')) {
-							$value = $this->remove_placeholder_escape($value);
+						if (!is_null($value)) {
+							$value = $this->_real_escape($value);
+
+							if (method_exists($this, 'remove_placeholder_escape')) {
+								$value = $this->remove_placeholder_escape($value);
+							}
+							$buffer .= "'" . $value . "', ";
+						} else {
+							$buffer .= "null, ";
 						}
-						
-						$buffer .= "'".$value."', ";
 					}
 					$buffer = rtrim($buffer, ', ').");\n";
 					$this->fs->get_tmp_filesystem_append()->write($dumpfile, $buffer);


### PR DESCRIPTION
We found some problems with xcloner and the User Access Manager (UAM) plugin.
The plugin has a table called `wp_uam_accessgroup_to_object`. This table contains the datetime columns `from_date` and `to_date` which are normaly `null`.
After xcloner backup and xcloner restore we realized that the datetime columns contains the following value "0000-00-00 00:00:00" instead of `null`.
And therefore the UAM plugin didn't work as expected.

The reason for the value "0000-00-00 00:00:00" is: xcloner generates following insert statement
`INSERT INTO wp_uam_accessgroup_to_object VALUES ('...', '...', '...', '...', '...', '', '');`

instead of

`INSERT INTO wp_uam_accessgroup_to_object VALUES ('...', '...', '...', '...', '...', null, null);`

I pushed a change in class-xcloner-database.php which should fix the issue.

Best regards 
Jochen